### PR TITLE
fix pyc_magic: Restore the value of pyc_magic with the header of stru…

### DIFF
--- a/pyinstxtractor.py
+++ b/pyinstxtractor.py
@@ -257,6 +257,11 @@ class PyInstArchive:
 
 
     def _writeRawData(self, filepath, data):
+        # `struct.pyc` contains the value of `pyc_magic` in the packaging environment
+        # So we use it to replace the default value of `pyc_magic`
+        global pyc_magic
+        if filepath == "struct.pyc":
+            pyc_magic = data[:4]
         nm = filepath.replace('\\', os.path.sep).replace('/', os.path.sep).replace('..', '__')
         nmDir = os.path.dirname(nm)
         if nmDir != '' and not os.path.exists(nmDir): # Check if path exists, create if not

--- a/pyinstxtractor.py
+++ b/pyinstxtractor.py
@@ -279,6 +279,7 @@ class PyInstArchive:
             os.mkdir(extractionDir)
 
         os.chdir(extractionDir)
+        pyc_list = []
 
         for entry in self.tocList:
             self.fPtr.seek(entry.position, os.SEEK_SET)
@@ -305,8 +306,7 @@ class PyInstArchive:
             if entry.typeCmprsData == b's':
                 # s -> ARCHIVE_ITEM_PYSOURCE
                 # Entry point are expected to be python scripts
-                print('[+] Possible entry point: {0}.pyc'.format(entry.name))
-                self._writePyc(entry.name + '.pyc', data)
+                pyc_list.append(( entry.name+".pyc", data ))
 
             elif entry.typeCmprsData == b'M' or entry.typeCmprsData == b'm':
                 # M -> ARCHIVE_ITEM_PYPACKAGE
@@ -320,6 +320,9 @@ class PyInstArchive:
                 if entry.typeCmprsData == b'z' or entry.typeCmprsData == b'Z':
                     self._extractPyz(entry.name)
 
+        for pyc_filename, data in pyc_list:
+            print('[+] Possible entry point: {0}'.format(pyc_filename))
+            self._writePyc(pyc_filename, data)
 
     def _writePyc(self, filename, data):
         with open(filename, 'wb') as pycFile:

--- a/pyinstxtractor.py
+++ b/pyinstxtractor.py
@@ -332,6 +332,7 @@ class PyInstArchive:
                         'pyiboot01_bootstrap.pyc',
                         'pyi_rth_subprocess.pyc',
                         'pyi_rth_pkgutil.pyc',
+                        'pyi_rth_multiprocessing.pyc',
                         'pyi_rth_inspect.pyc'
                     )
         ]


### PR DESCRIPTION
When writing a pyc file (`PyInstArchive._writePyc(self, filename, data)`), the `pyc_magic` used is different from the value of the original file, which will cause an error in decompiling the pyc-file (`$ uncompple6 [pyc-file]`). 

To solve this problem, I choose to retrieve the pyc_magic of the original file from the first four bytes of the `struct.pyc` file to ensure that the extracted pyc-file can be decompiled.