### PR TITLE
Do not abort after the first extraction error

### DIFF
--- a/pyinstxtractor.py
+++ b/pyinstxtractor.py
@@ -279,7 +279,11 @@ class PyInstArchive:
             data = self.fPtr.read(entry.cmprsdDataSize)
 
             if entry.cmprsFlag == 1:
-                data = zlib.decompress(data)
+                try:
+                    data = zlib.decompress(data)
+                except zlib.error:
+                    print('[!] Error : Failed to decompress {0}'.format(entry.name))
+                    continue
                 # Malware may tamper with the uncompressed size
                 # Comment out the assertion in such a case
                 assert len(data) == entry.uncmprsdDataSize # Sanity Check


### PR DESCRIPTION
Do not abort after the first extraction error; continue with the next file instead.

I came across the case where a single `dll` file wouldn't extract properly, but it would abort the whole script.
Instead, continue with the next file, so that we still get maximum useful output.