### PR TITLE
Make it library friendly to be able to integrate to another projects

### DIFF
--- a/pyinstxtractor.py
+++ b/pyinstxtractor.py
@@ -83,15 +83,14 @@ Version 2.0 (March 26, 2020)
 - The header of all extracted pyc's are now automatically fixed
 """
 
-from __future__ import print_function
+import logging
+import marshal
 import os
 import struct
-import marshal
-import zlib
 import sys
-from uuid import uuid4 as uniquename
+import zlib
 from contextlib import suppress
-import logging
+from uuid import uuid4 as uniquename
 
 log = logging.getLogger()
 
@@ -188,7 +187,7 @@ class PyInstArchive:
             return False
 
         self.pymaj, self.pymin = (pyver // 100, pyver % 100) if pyver >= 100 else (pyver // 10, pyver % 10)
-        log.debug("[+] Python version: {0}.{1}".format(self.pymaj, self.pymin))
+        log.debug("[+] Python version: %d.%d", self.pymaj, self.pymin)
 
         # Additional data after the cookie
         tailBytes = (

--- a/pyinstxtractor.py
+++ b/pyinstxtractor.py
@@ -444,7 +444,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("-f", "--file", action="store")
     parser.add_argument("-d", "--destination-folder", action="store", help="Folder to store extracted files")
-    parser.add_argument("-e", "--entry-points", action="store_true", help="Extract only possibble entry points")
+    parser.add_argument("-e", "--entry-points", action="store_true", help="Extract only possible entry points")
 
     options = parser.parse_args()
     if not options.file or not os.path.exists(options.file):


### PR DESCRIPTION
Hello, first of all thank you for your tool. I did it more library friendly to be integrated into another projects. Feel free to reject if you don't like the changes

```
python3 pyinstxtractor.py -h
usage: PyInstaller Extractor [-h] [-f FILE] [-d DESTINATION_FOLDER] [-e]

PyInstaller Extractor is a Python script to extract the contents of a PyInstaller generated executable file.

options:
  -h, --help            show this help message and exit
  -f, --file FILE
  -d, --destination-folder DESTINATION_FOLDER
                        Folder to store extracted files
  -e, --entry-points    Extract only possible entry points

```